### PR TITLE
ci(deploy): Fix docker-compose to restart container

### DIFF
--- a/production.yml
+++ b/production.yml
@@ -19,6 +19,7 @@ services:
       - ./.envs/.production/.django
       - ./.envs/.production/.postgres
     command: /start
+    restart: always
 
   histomx:
     build:
@@ -26,6 +27,7 @@ services:
       dockerfile: ./compose/local/histomx/Dockerfile
     image: icdot_production_histomx
     container_name: histomx
+    restart: always
 
   postgres:
     build:
@@ -37,6 +39,7 @@ services:
       - production_postgres_data_backups:/backups:z
     env_file:
       - ./.envs/.production/.postgres
+    restart: always
 
   traefik:
     build:
@@ -50,6 +53,8 @@ services:
     ports:
       - "0.0.0.0:80:80"
       - "0.0.0.0:443:443"
+    restart: always
 
   redis:
     image: redis:6
+    restart: always

--- a/production_nodb_nossl.yml
+++ b/production_nodb_nossl.yml
@@ -21,6 +21,7 @@ services:
       - 0.0.0.0:80:5000
     extra_hosts:
       - postgres:host-gateway
+    restart: always
 
   histomx:
     build:
@@ -34,6 +35,7 @@ services:
       # Sadly rmarkdown must have rw access to be able to knit.
       # As long as we're running only trusted code that's fine.
       - /fs1/app/histomx:/histomx:rw
+    restart: always
 
   redis:
     image: redis:6

--- a/production_nodb_nossl.yml
+++ b/production_nodb_nossl.yml
@@ -39,3 +39,4 @@ services:
 
   redis:
     image: redis:6
+    restart: always


### PR DESCRIPTION
This feature will make the containers restart on startup. Please not that it will not restart docker itself; I can write a service file to do that if needed.

I think it is only needed in the nodb_nossl file but I added it to both production file as it won't be a problem anyway.